### PR TITLE
Fix URL

### DIFF
--- a/src/main/java/me/noroutine/jenkins/plugin/consolebadge/ThatUsefulBadgeIAlwaysMissed.java
+++ b/src/main/java/me/noroutine/jenkins/plugin/consolebadge/ThatUsefulBadgeIAlwaysMissed.java
@@ -35,7 +35,7 @@ public class ThatUsefulBadgeIAlwaysMissed implements BuildBadgeAction {
     }
 
     public String getConsolePath() {
-        return Integer.toString(this.run.getNumber()) + "/console";
+        return "/" + this.run.getUrl() + "console";
     }
 
     @Extension(dynamicLoadable = YesNoMaybe.YES)


### PR DESCRIPTION
Hi!

Nice plugin, thank you.

I've noticed though that your plugin shows wrong links on other pages than project page, like workspace page (/job/JobName/ws). This MR fixes it. 

I've used this.run.getUrl() instead of getNumber(), it returns a correct URL to build relative to server name, so I've added a '/' at start.
