### PR TITLE
Fix problem with incorrect link in sidebar menu

### DIFF
--- a/src/main/java/me/noroutine/jenkins/plugin/consolebadge/kanaduchi
+++ b/src/main/java/me/noroutine/jenkins/plugin/consolebadge/kanaduchi
@@ -31,7 +31,7 @@ public class ThatUsefulBadgeIAlwaysMissed implements BuildBadgeAction {
 
     @Override
     public String getUrlName() {
-        return "consoleBadge";
+        return "console";
     }
 
     public String getConsolePath() {


### PR DESCRIPTION
We have a problem that in side bar we have incorrect link to console:
https://localhost/view/SUITE/job/Autotests/27/consoleBadge